### PR TITLE
Release v0.1.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,11 +27,16 @@ jobs:
         run: ci/download-stanza.sh
         working-directory: ${{ github.workspace }}
 
+      - name: Set up authentication
+        run: ci/setup-askpass.sh
+
       - name: Bootstrap and build
         working-directory: ${{ github.workspace }}
         run: |
+          cat ${{ github.workspace }}/.git-env
+          source ${{ github.workspace }}/.git-env
           cat ${{ github.workspace }}/stanza.env
           source ${{ github.workspace }}/stanza.env
           ci/build.sh
         env:
-          CI_PAT: ${{ secrets.CI_PAT }}
+          CI_TOKEN: ${{ secrets.CI_PAT }}

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -31,13 +31,7 @@ def version_to_tag(version):
         return f"v{version}"
 
 def package_to_url(package):
-    # Check for CI PAT for access to private repos
-    # (see .github/workflows/main.yml)
-    if 'CI_PAT' in os.environ:
-        return f"https://tylanphear:{os.environ['CI_PAT']}@github.com/{package}"
-    # Otherwise assume user has SSH access to our dependencies
-    else:
-        return "git@github.com:" + package
+    return f"https://github.com/{package}"
 
 def fetch_package_into(path, package, version):
     rev = version_to_tag(version)

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -31,7 +31,13 @@ def version_to_tag(version):
         return f"v{version}"
 
 def package_to_url(package):
-    return f"https://github.com/{package}"
+    # Check for CI PAT for access to private repos
+    # (see .github/workflows/main.yml)
+    if 'GIT_ASKPASS' in os.environ:
+        return f"https://github.com/{package}"
+    # Otherwise assume user has SSH access to our dependencies
+    else:
+        return f"git@github.com:{package}"
 
 def fetch_package_into(path, package, version):
     rev = version_to_tag(version)

--- a/ci/setup-askpass.sh
+++ b/ci/setup-askpass.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+cat > "${GITHUB_WORKSPACE}/.git-askpass" <<EOF
+echo \$CI_TOKEN
+EOF
+chmod +x "${GITHUB_WORKSPACE}/.git-askpass"
+
+cat > "${GITHUB_WORKSPACE}/.git-env" <<EOF
+export GIT_ASKPASS="${GITHUB_WORKSPACE}/.git-askpass"
+EOF

--- a/poet.toml
+++ b/poet.toml
@@ -1,6 +1,6 @@
 name = "poet"
-version = "0.0.5"
+version = "0.1.0"
 
 [dependencies]
-stanza-toml = "git@github.com:tylanphear/stanza-toml|latest"
-maybe-utils = "git@github.com:tylanphear/maybe-utils|0.0.3"
+stanza-toml = "tylanphear/stanza-toml|latest"
+maybe-utils = "tylanphear/maybe-utils|0.0.3"

--- a/src/commands/build.stanza
+++ b/src/commands/build.stanza
@@ -21,7 +21,6 @@ defn parse-poet-lock-file (path: String) -> HashTable<String, String>:
 defn sync-dependency (
   dep: Dependency,
   hash?: Maybe<String>,
-  ref?: Maybe<String>,
   force?: True|False,
 ) -> True|False:
 
@@ -41,7 +40,7 @@ defn sync-dependency (
       if force?:
         info("build: syncing '%_'" % [spec(dep)])
 
-        val ref = ref? $> value-or{_, "HEAD"}
+        val ref = ref(dep)
         val reset-ref = ref when ref != "HEAD" else "origin/HEAD"
 
         git(["fetch", "--quiet", "--force", "origin", ref])
@@ -87,8 +86,8 @@ defn clone-and-checkout-dependency (dep: Dependency) -> False:
   info("build: cloning %_" % [spec(dep)])
 
   shallow-clone-git-repo(uri(dep), path(dep))
-  val revision = version?(dep)
-    $> and-then{_, parse-version}
+  val revision = version(dep)
+    $> parse-version
     $> and-then{_, version-tag?}
     $> map{_, fn (tag):
       val refspec = to-string $ "+refs/tags/%_:refs/tags/%_" % [tag, tag]
@@ -144,7 +143,7 @@ defn fetch-and-sync-dependencies () -> False:
 
           val hash? = get?(dependency-hashes, name(dependency)) $> to-maybe
           val in-sync? = if file-exists?(path(dependency)):
-            sync-dependency(dependency, hash?, version?(dependency), false)
+            sync-dependency(dependency, hash?, false)
           else:
             clone-and-checkout-dependency(dependency)
 

--- a/src/dependency.stanza
+++ b/src/dependency.stanza
@@ -4,22 +4,34 @@ defpackage poet/dependency:
 
 public defstruct Dependency:
   name: String
-  uri: String
-  version?: Maybe<String>
+  locator: String
+  version: String
 
 public defn path (dep: Dependency) -> String:
   to-string $ ".poet/deps/%_" % [name(dep)]
 
 public defn spec (dep: Dependency) -> String:
-  to-string $ "%_|%_"
-    % [name(dep), version?(dep) $> value-or{_, "latest"}]
+  to-string $ "%_|%_" % [name(dep), version(dep)]
+
+public defn ref (dep: Dependency) -> String:
+  if version(dep) == "latest":
+    "HEAD"
+  else:
+    version(dep)
+
+public defn uri (dep: Dependency) -> String:
+  if get-env("GIT_ASKPASS") is String:
+    to-string("https://github.com/%_" % [locator(dep)])
+  else:
+    to-string("git@github.com:%_" % [locator(dep)])
 
 public defn parse-dependency (name: String, locator: String) -> Maybe<Dependency>:
   val elements = to-tuple $ split(locator, "|")
 
-  if length(elements) $> contains?{[1, 2], _}:
-    val uri = elements[0]
-    val version? = One(elements[1]) when length(elements) > 1 else None()
-    One(Dependency(name, uri, version?))
-  else:
-    None()
+  switch(length(elements)):
+    2:
+      val locator = elements[0]
+      val version = elements[1]
+      One(Dependency(name, locator, version))
+    else:
+      None()


### PR DESCRIPTION
- Change `poet.toml` specifier format to not specify the full URL with a protocol (e.g. `git` or `https:`) and instead let `poet` form the proper protocol to use automatically.
- Use `https` to sync/fetch dependencies when `GIT_ASKPASS` is set. (Necessary so CI can clone dependencies properly)
- Enforce that every locator contains a version (e.g. `foo/bar|latest`)