### PR TITLE
Add `POET_PROTOCOL` env variable, remove `GIT_ASKPASS` support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,3 +40,4 @@ jobs:
           ci/build.sh
         env:
           CI_TOKEN: ${{ secrets.CI_PAT }}
+          POET_PROTOCOL: https

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -31,13 +31,11 @@ def version_to_tag(version):
         return f"v{version}"
 
 def package_to_url(package):
-    # Check for CI PAT for access to private repos
-    # (see .github/workflows/main.yml)
-    if 'GIT_ASKPASS' in os.environ:
-        return f"https://github.com/{package}"
-    # Otherwise assume user has SSH access to our dependencies
-    else:
-        return f"git@github.com:{package}"
+    def git_url(package): return f"git@github.com:{package}"
+    def https_url(package): return f"https://github.com/{package}"
+    PROTOCOLS = { "git": git_url, "https": https_url, None: git_url }
+
+    return PROTOCOLS[os.environ.get("POET_PROTOCOL")](package)
 
 def fetch_package_into(path, package, version):
     rev = version_to_tag(version)

--- a/src/commands/build.stanza
+++ b/src/commands/build.stanza
@@ -84,6 +84,7 @@ defmethod version-tag? (version: LatestVersion) -> None:
 
 defn clone-and-checkout-dependency (dep: Dependency) -> False:
   info("build: cloning %_" % [spec(dep)])
+  debug("build: clone: %_" % [uri(dep)])
 
   shallow-clone-git-repo(uri(dep), path(dep))
   val revision = version(dep)

--- a/src/dependency.stanza
+++ b/src/dependency.stanza
@@ -1,6 +1,7 @@
 defpackage poet/dependency:
   import core
   import maybe-utils
+  import poet/utils
 
 public defstruct Dependency:
   name: String
@@ -20,10 +21,7 @@ public defn ref (dep: Dependency) -> String:
     version(dep)
 
 public defn uri (dep: Dependency) -> String:
-  if get-env("GIT_ASKPASS") is String:
-    to-string("https://github.com/%_" % [locator(dep)])
-  else:
-    to-string("git@github.com:%_" % [locator(dep)])
+  full-url-from-locator(locator(dep))
 
 public defn parse-dependency (name: String, locator: String) -> Maybe<Dependency>:
   val elements = to-tuple $ split(locator, "|")

--- a/src/utils.stanza
+++ b/src/utils.stanza
@@ -220,3 +220,12 @@ public defn base-name? (path: String) -> Maybe<String>:
     $> map{_, {[_]}}
     $> map{_, ParsedPath}
     $> map{_, to-string}
+
+public defn full-url-from-locator (locator: String) -> String:
+  defn git-locator (locator: String): (to-string("git@github.com:%_" % [locator]))
+  defn https-locator (locator: String): (to-string("https://github.com/%_" % [locator]))
+
+  switch(get-env("POET_PROTOCOL")):
+    "git": git-locator(locator)
+    "https": https-locator(locator)
+    false: git-locator(locator)


### PR DESCRIPTION
Control the protocol `poet` uses explicitly using the `POET_PROTOCOL` environment variable, rather than using this weird specific support for `GIT_ASKPASS`.

Supports two values:
- `git`: which forms a URL for the locator using the scheme `git@github.com:<locator>`
- `https`: which forms a URL for the locator using the scheme `https://github.com:<locator>`

When unset, the default is to use `git`.

Also: switch the CI over to using `POET_PROTOCOL=https`, and add support in `./bootstrap.py`.