### PR TITLE
build: don't fatal when `POET_PROTOCOL` is set to an invalid value

### DIFF
--- a/src/utils.stanza
+++ b/src/utils.stanza
@@ -228,4 +228,4 @@ public defn full-url-from-locator (locator: String) -> String:
   switch(get-env("POET_PROTOCOL")):
     "git": git-locator(locator)
     "https": https-locator(locator)
-    false: git-locator(locator)
+    else: git-locator(locator)


### PR DESCRIPTION
Was due to the lack of a catch-all clause in the `switch`.