### PR TITLE
ci: don't run CI on merge to master (no longer necessary).

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,6 @@
 name: CI
 
 on:
-  # Triggers on pushes to master
-  push:
-    branches: [ master ]
-
   pull_request:
 
   # Allows running manually from the Actions tab


### PR DESCRIPTION
Due to the repository settings not allowing pushes to master without a PR, it's not possible to merge to master without the changes being clean in the first place.

This avoids an unnecessary second run of the CI after every PR merge onto master.