### PR TITLE
Revert "ci: don't run CI on merge to master (no longer necessary)."

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: CI
 
 on:
+  # Triggers on pushes to master
+  push:
+    branches: [ master ]
+
   pull_request:
 
   # Allows running manually from the Actions tab


### PR DESCRIPTION
Reverts tylanphear/poet#11

It turns out that not running the CI on merge to `master` means we don't get a check mark on `master` anymore, which is annoying. Not worth it. The CI is quick so there's no real reason to avoid running it twice right now (and we should probably keep it quick).