### PR TITLE
stanza-toml: pin version to `0.1.8`.

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -8,7 +8,7 @@ from subprocess import CalledProcessError
 
 # Keep in sync with `poet.toml`
 DEPENDENCIES = {
-        "stanza-toml": "tylanphear/stanza-toml|latest",
+        "stanza-toml": "tylanphear/stanza-toml|0.1.8",
         "maybe-utils": "tylanphear/maybe-utils|0.0.3",
 }
 

--- a/poet.toml
+++ b/poet.toml
@@ -2,5 +2,5 @@ name = "poet"
 version = "0.1.0"
 
 [dependencies]
-stanza-toml = "tylanphear/stanza-toml|latest"
+stanza-toml = "tylanphear/stanza-toml|0.1.8"
 maybe-utils = "tylanphear/maybe-utils|0.0.3"


### PR DESCRIPTION
Using `latest` won't work right now because of breaking changes introduced in `0.2.0`.

(side note: yay, first win for `poet`!)