### PR TITLE
v0.1.2: colorize output using `term-colors` when possible.

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -11,6 +11,7 @@ DEPENDENCIES = {
         "stanza-toml": "tylanphear/stanza-toml|0.3.0",
         "maybe-utils": "tylanphear/maybe-utils|0.1.2",
         "semver": "tylanphear/semver|0.1.3",
+        "term-colors": "tylanphear/term-colors|0.1.0",
 }
 
 POET_DIR = os.path.join(os.getcwd(), ".poet")

--- a/poet.toml
+++ b/poet.toml
@@ -1,7 +1,8 @@
 name = "poet"
-version = "0.1.0"
+version = "0.1.2"
 
 [dependencies]
 stanza-toml = "tylanphear/stanza-toml|0.3.0"
 semver      = "tylanphear/semver|0.1.3"
 maybe-utils = "tylanphear/maybe-utils|0.1.1"
+term-colors = "tylanphear/term-colors|0.1.0"

--- a/src/commands/build.stanza
+++ b/src/commands/build.stanza
@@ -6,6 +6,7 @@ defpackage poet/commands/build:
   import poet/utils
   import poet/lock
   import semver
+  import term-colors
   import toml/parser
   import toml/file
   import toml/table
@@ -16,6 +17,16 @@ defstruct Dependency:
   locator: String
   version: SemanticVersion
   hash: String
+
+defn colored-version? (s: SemanticVersion) -> ColoredString:
+  ColoredString(to-string(s))
+    $> bold $> foreground{_, TerminalBrightGreen}
+    $> clear-color?
+
+defn colored-name? (name: String) -> ColoredString:
+  ColoredString(name)
+    $> bold $> foreground{_, TerminalBrightWhite}
+    $> clear-color?
 
 defn parse-specifier (specifier: String) -> [String, SemanticVersion]:
   val elements = to-tuple $ split(specifier, "|")
@@ -50,7 +61,7 @@ defn fetch-dependency (
   locator: String,
   hash: String,
 ) -> False:
-  info("build: cloning '%_' at %_" % [name, hash])
+  info("build: cloning %_ at %_" % [colored-name?(name), hash])
 
   val url = full-url-from-locator(locator)
   shallow-clone-git-repo(url, dir)
@@ -66,7 +77,7 @@ defn fetch-dependency (
   locator: String,
   version: SemanticVersion,
 ) -> False:
-  info("build: cloning '%_' at %~" % [name, version])
+  info("build: cloning %_ at %~" % [colored-name?(name), colored-version?(version)])
 
   val url = full-url-from-locator(locator)
   shallow-clone-git-repo(url, dir)
@@ -117,7 +128,7 @@ defn sync-dependency (
   debug("build: tag-hash: %_" % [tag-hash])
 
   if tag-hash != head-hash:
-    info("build: syncing '%_' to '%~'" % [name, version])
+    info("build: syncing %_ to %~" % [colored-name?(name), colored-version?(version)])
     run-git-command-in-dir(dir, ["checkout", "--quiet", "--force", tag])
 
   false
@@ -134,15 +145,16 @@ defn parse-poet-toml-and-resolve-dependencies () -> HashTable<String, Dependency
       for [name, specifier] in pairs(dependencies) seq?:
         label<Maybe<KeyValue<String, Dependency>>> return:
           val [locator, requested-version] = parse-specifier(specifier as String)
-          debug("build: trying to resolve '%_' at %_" % [name, version])
+          debug("build: trying to resolve %_ at %_" % [colored-name?(name), version])
 
           val resolved-version = match(get?(resolved-dependencies, name)):
             (resolved-dependency: Dependency):
               val resolved-version = version(resolved-dependency)
               if not compatible?(requested-version, resolved-version):
-                error("build: can't resolve dependencies: incompatible versions of `%_`\n\
+                error("build: can't resolve dependencies: incompatible versions of %_\n\
                        resolved:  %~\n\
-                       requested: %~" % [name, resolved-version, requested-version])
+                       requested: %~"
+                       % [colored-name?(name), resolved-version, requested-version])
               else if resolved-version >= requested-version:
                 debug("build: re-using previously resolved version at %_"
                       % [resolved-version])
@@ -168,7 +180,7 @@ defn parse-poet-toml-and-resolve-dependencies () -> HashTable<String, Dependency
           ))
 
     for [name, dep] in pairs(newly-resolved) do:
-      debug("build: resolved '%_' at %_" % [name, version(dep)])
+      debug("build: resolved %_ at %_" % [colored-name?(name), version(dep)])
       resolved-dependencies[name] = dep
 
     for dep in keys(newly-resolved) do:

--- a/src/utils.stanza
+++ b/src/utils.stanza
@@ -1,19 +1,48 @@
 defpackage poet/utils:
-    import core
-    import core/parsed-path
-    import collections
-    import maybe-utils
+  import core
+  import core/parsed-path
+  import collections
+  import maybe-utils
+  import term-colors
 
 public defn program-name () -> String:
   val program-path = command-line-arguments()[0]
   program-path $> base-name? $> value-or{_, program-path}
 
+defn colored-program-prefix () -> ColoredString:
+  val prefix = to-string("%_:" % [program-name()])
+  ColoredString(prefix, ColorSpec() $> bold $> foreground{_, TerminalBrightWhite})
+
+defn supports-color? () -> True|False:
+  switch(get-env("POET_COLOR")):
+    "always": true
+    "never": false
+    else: true
+
+defn program-prefix () -> ColoredString|String:
+  if supports-color?():
+    colored-program-prefix()
+  else:
+    to-string("%_:" % [program-name()])
+
+public defn clear-color? (c: ColoredString) -> ColoredString:
+  if not supports-color?():
+    c $> clear
+  else:
+    c
+
 public defn debug (msg: Printable|String) -> False:
   if poet/flags/debug?:
-    println(STANDARD-ERROR-STREAM, "%_: debug: %_" % [program-name(), msg])
+    println(STANDARD-ERROR-STREAM, "%_ %_ %_" % [
+      program-prefix(),
+      ColoredString("debug:")
+        $> bold $> dim $> foreground{_, TerminalYellow}
+        $> clear-color?,
+      msg,
+    ])
 
 public defn info (msg: Printable|String) -> False:
-  println(STANDARD-OUTPUT-STREAM, "%_: %_" % [program-name(), msg])
+  println(STANDARD-OUTPUT-STREAM, "%_ %_" % [program-prefix(), msg])
   flush(STANDARD-OUTPUT-STREAM as FileOutputStream)
 
 public defn error-with-usage (msg: Printable|String) -> Void:
@@ -24,7 +53,13 @@ public defn error (msg: Printable|String) -> Void:
 
 defn error (msg: Printable|String, usage?: True|False) -> Void:
   val program = program-name()
-  println(STANDARD-ERROR-STREAM, "%_: %_" % [program, msg])
+  println(STANDARD-ERROR-STREAM, "%_ %_ %_" % [
+    program-prefix(),
+    ColoredString("error:")
+      $> bold $> foreground{_, TerminalBrightRed}
+      $> clear-color?,
+    msg,
+  ])
   if usage?:
     println(STANDARD-ERROR-STREAM, "usage: %_ [build|clean|init|publish]" % [program])
   exit(1)


### PR DESCRIPTION
- Colorize output when emitting info, error and debug messages.

- Add a environment variable `POET_COLOR` that controls colorization behavior. It currently has two supported values:

  - `always`: when set, `poet` always attempts to colorize output.
  - `never`: when set, `poet` never attempts to colorize output.

  When unset, colorization is always attempted. In the future, some level of terminal detection should be employed (e.g. to check if `poet`'s output is being redirected to a file)